### PR TITLE
v0.3.0

### DIFF
--- a/absql/__init__.py
+++ b/absql/__init__.py
@@ -9,7 +9,7 @@ from absql.text import (
     flatten_inputs,
     pretty_encode_sql,
 )
-from absql.utils import nested_apply, get_function_arg_names, partialize_function
+from absql.utils import nested_apply, partialize_function
 
 
 class Runner:
@@ -26,7 +26,9 @@ class Runner:
         self.file_context_from = file_context_from
 
     @staticmethod
-    def render_text(text, replace_only=False, pretty_encode=False, **vars):
+    def render_text(
+        text, replace_only=False, pretty_encode=False, partial_kwargs=None, **vars
+    ):
         """
         Given some text, render the template with the vars.
         If a templated variable is unknown, leave it alone.
@@ -35,11 +37,10 @@ class Runner:
         # Allows an instantiated SQLAlchemy engine to be utilized
         # in any function with a engine argument, without the user needing
         # to specify the engine in the function call.
-        engine = vars.get("engine", None)
+        partial_kwargs = partial_kwargs or ["engine"]
         for k, v in vars.items():
             if v.__class__.__name__ == "function":
-                if "engine" in get_function_arg_names(v):
-                    vars[k] = partialize_function(v, engine=engine)
+                vars[k] = partialize_function(v, partial_kwargs=partial_kwargs, **vars)
 
         if replace_only:
             text = clean_spacing(text)

--- a/absql/__init__.py
+++ b/absql/__init__.py
@@ -71,7 +71,7 @@ class Runner:
         current_context.update(extra_context)
 
         if text.endswith(accepted_file_types):
-            rendered = self.render_file(
+            rendered = render_file(
                 file_path=text,
                 loader=self.loader,
                 replace_only=replace_only or self.replace_only,
@@ -81,12 +81,12 @@ class Runner:
                 **current_context,
             )
         else:
-            rendered = self.render_text(
+            rendered = render_text(
                 text=text,
                 replace_only=replace_only or self.replace_only,
                 pretty_encode=pretty_encode,
                 partial_kwargs=self.partial_kwargs,
-                **self.render_context(
+                **render_context(
                     current_context, partial_kwargs=self.partial_kwargs
                 ),
             )

--- a/absql/__init__.py
+++ b/absql/__init__.py
@@ -18,12 +18,14 @@ class Runner:
         extra_constructors=None,
         replace_only=False,
         file_context_from=None,
+        partial_kwargs=None,
         **extra_context,
     ):
         self.extra_context = dict(extra_context)
         self.loader = generate_loader(extra_constructors or [])
         self.replace_only = replace_only
         self.file_context_from = file_context_from
+        self.partial_kwargs = partial_kwargs or ["engine"]
 
     @staticmethod
     def render_text(
@@ -37,7 +39,6 @@ class Runner:
         # Allows an instantiated SQLAlchemy engine to be utilized
         # in any function with a engine argument, without the user needing
         # to specify the engine in the function call.
-        partial_kwargs = partial_kwargs or ["engine"]
         for k, v in vars.items():
             if v.__class__.__name__ == "function":
                 vars[k] = partialize_function(v, partial_kwargs=partial_kwargs, **vars)
@@ -135,6 +136,7 @@ class Runner:
                 replace_only=replace_only or self.replace_only,
                 file_context_from=self.file_context_from,
                 pretty_encode=pretty_encode,
+                partial_kwargs=self.partial_kwargs,
                 **current_context,
             )
         else:
@@ -142,7 +144,10 @@ class Runner:
                 text=text,
                 replace_only=replace_only or self.replace_only,
                 pretty_encode=pretty_encode,
-                **self.render_context(current_context),
+                partial_kwargs=self.partial_kwargs,
+                **self.render_context(
+                    current_context, partial_kwargs=self.partial_kwargs
+                ),
             )
         return rendered
 

--- a/absql/__init__.py
+++ b/absql/__init__.py
@@ -58,7 +58,7 @@ class Runner:
             return text
 
     @staticmethod
-    def render_context(extra_context=None, file_contents=None):
+    def render_context(extra_context=None, file_contents=None, partial_kwargs=None):
         """
         Render context dictionaries passed through a function call or
         file frontmatter (file_contents), with file_contents taking
@@ -71,7 +71,9 @@ class Runner:
             rendered_context.update(**file_contents)
         rendered_context = nested_apply(
             rendered_context,
-            lambda x: Runner.render_text(x, **rendered_context),
+            lambda x: Runner.render_text(
+                x, partial_kwargs=partial_kwargs, **rendered_context
+            ),
         )
         return rendered_context
 
@@ -83,6 +85,7 @@ class Runner:
         extra_constructors=None,
         file_context_from=None,
         pretty_encode=False,
+        partial_kwargs=None,
         **extra_context,
     ):
         """
@@ -101,12 +104,15 @@ class Runner:
             file_contents.update(file_contents.get(file_context_from, {}))
             file_contents.pop(file_context_from, {})
 
-        rendered_context = Runner.render_context(extra_context, file_contents)
+        rendered_context = Runner.render_context(
+            extra_context, file_contents, partial_kwargs
+        )
 
         rendered = Runner.render_text(
             text=sql,
             replace_only=replace_only,
             pretty_encode=pretty_encode,
+            partial_kwargs=partial_kwargs,
             **rendered_context,
         )
 

--- a/absql/__init__.py
+++ b/absql/__init__.py
@@ -2,6 +2,7 @@ from absql.files import accepted_file_types
 from absql.files.loader import generate_loader
 from absql.render import render_text, render_context, render_file
 
+
 class Runner:
     def __init__(
         self,

--- a/absql/__init__.py
+++ b/absql/__init__.py
@@ -9,7 +9,7 @@ from absql.text import (
     flatten_inputs,
     pretty_encode_sql,
 )
-from absql.utils import nested_apply, get_function_arg_names, partialize_engine_func
+from absql.utils import nested_apply, get_function_arg_names, partialize_function
 
 
 class Runner:
@@ -39,7 +39,7 @@ class Runner:
         for k, v in vars.items():
             if v.__class__.__name__ == "function":
                 if "engine" in get_function_arg_names(v):
-                    vars[k] = partialize_engine_func(v, engine=engine)
+                    vars[k] = partialize_function(v, engine=engine)
 
         if replace_only:
             text = clean_spacing(text)

--- a/absql/functions/db.py
+++ b/absql/functions/db.py
@@ -1,5 +1,5 @@
 from absql.functions.env import env_var
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.engine.base import Engine
 
 
@@ -22,7 +22,8 @@ def query_db(query, engine_env="AB__URI", engine=None):
     engine = (
         handle_engine(env_var(engine_env)) if engine is None else handle_engine(engine)
     )
-    return engine.execute(query).fetchall()
+    with engine.connect() as connection:
+        return connection.execute(text(query)).fetchall()
 
 
 def handle_engine(engine):

--- a/absql/render/__init__.py
+++ b/absql/render/__init__.py
@@ -1,0 +1,100 @@
+from inspect import cleandoc
+from jinja2 import Template, DebugUndefined
+from absql.text import (
+    clean_spacing,
+    create_replacements,
+    flatten_inputs,
+    pretty_encode_sql,
+)
+from absql.files import parse
+from absql.files.loader import generate_loader
+from absql.functions import default_functions
+from absql.utils import nested_apply, partialize_function
+
+
+def render_text(
+    text, replace_only=False, pretty_encode=False, partial_kwargs=None, **vars
+):
+    """
+    Given some text, render the template with the vars.
+    If a templated variable is unknown, leave it alone.
+    """
+
+    # Allows an instantiated SQLAlchemy engine to be utilized
+    # in any function with a engine argument, without the user needing
+    # to specify the engine in the function call.
+    for k, v in vars.items():
+        if v.__class__.__name__ == "function":
+            vars[k] = partialize_function(v, partial_kwargs=partial_kwargs, **vars)
+
+    if replace_only:
+        text = clean_spacing(text)
+        flat_vars = flatten_inputs(**vars)
+        replacements = create_replacements(**flat_vars)
+        for k, v in replacements.items():
+            text = text.replace(k, str(v))
+        text = cleandoc(text)
+    else:
+        template = Template(text, undefined=DebugUndefined)
+        text = cleandoc(template.render(**vars))
+    if pretty_encode:
+        return pretty_encode_sql(text)
+    else:
+        return text
+
+
+def render_context(extra_context=None, file_contents=None, partial_kwargs=None):
+    """
+    Render context dictionaries passed through a function call or
+    file frontmatter (file_contents), with file_contents taking
+    precedence over other all other provided context.
+    """
+    rendered_context = default_functions.copy()
+    if extra_context:
+        rendered_context.update(**extra_context)
+    if file_contents:
+        rendered_context.update(**file_contents)
+    rendered_context = nested_apply(
+        rendered_context,
+        lambda x: render_text(x, partial_kwargs=partial_kwargs, **rendered_context),
+    )
+    return rendered_context
+
+
+def render_file(
+    file_path,
+    loader=None,
+    replace_only=False,
+    extra_constructors=None,
+    file_context_from=None,
+    pretty_encode=False,
+    partial_kwargs=None,
+    **extra_context,
+):
+    """
+    Given a file path, render SQL with a combination of
+    the vars in the file and any extras passed to extra_context.
+    """
+    if loader is None:
+        loader = generate_loader(extra_constructors or [])
+
+    file_contents = parse(file_path, loader=loader)
+
+    sql = file_contents["sql"]
+    file_contents.pop("sql")
+
+    if file_context_from:
+        file_contents.update(file_contents.get(file_context_from, {}))
+        file_contents.pop(file_context_from, {})
+
+    rendered_context = render_context(extra_context, file_contents, partial_kwargs)
+
+    rendered = render_text(
+        text=sql,
+        replace_only=replace_only,
+        pretty_encode=pretty_encode,
+        partial_kwargs=partial_kwargs,
+        **rendered_context,
+    )
+
+    return rendered

--- a/absql/utils/__init__.py
+++ b/absql/utils/__init__.py
@@ -19,8 +19,13 @@ def nested_apply(x, f):
 def get_function_arg_names(func):
     return list(signature(func).parameters.keys())
 
-def partialize_function(func, engine):
-    if "engine" in get_function_arg_names(func):
-        return partial(func, engine=engine)
+
+def partialize_function(func, partial_kwargs=["engine"], **kwargs):
+    function_args = get_function_arg_names(func)
+
+    kwargs_to_partialize = {k: v for k, v in kwargs.items() if k in function_args}
+
+    if kwargs_to_partialize:
+        return partial(func, **kwargs_to_partialize)
     else:
         return func

--- a/absql/utils/__init__.py
+++ b/absql/utils/__init__.py
@@ -20,7 +20,8 @@ def get_function_arg_names(func):
     return list(signature(func).parameters.keys())
 
 
-def partialize_function(func, partial_kwargs=["engine"], **kwargs):
+def partialize_function(func, partial_kwargs=None, **kwargs):
+    partial_kwargs = partial_kwargs or ["engine"]
     function_args = get_function_arg_names(func)
 
     kwargs_to_partialize = {

--- a/absql/utils/__init__.py
+++ b/absql/utils/__init__.py
@@ -23,7 +23,9 @@ def get_function_arg_names(func):
 def partialize_function(func, partial_kwargs=["engine"], **kwargs):
     function_args = get_function_arg_names(func)
 
-    kwargs_to_partialize = {k: v for k, v in kwargs.items() if k in function_args}
+    kwargs_to_partialize = {
+        k: v for k, v in kwargs.items() if k in function_args and k in partial_kwargs
+    }
 
     if kwargs_to_partialize:
         return partial(func, **kwargs_to_partialize)

--- a/absql/utils/__init__.py
+++ b/absql/utils/__init__.py
@@ -19,8 +19,7 @@ def nested_apply(x, f):
 def get_function_arg_names(func):
     return list(signature(func).parameters.keys())
 
-
-def partialize_engine_func(func, engine):
+def partialize_function(func, engine):
     if "engine" in get_function_arg_names(func):
         return partial(func, engine=engine)
     else:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,11 +1,11 @@
 colorama==0.4.6
-duckdb==0.6.0
-duckdb-engine==0.6.4
+duckdb==0.7.0
+duckdb-engine==0.6.8
 flatdict==4.0.1
 Jinja2==3.1.2
-mock==4.0.3
-pandas==1.5.1
+mock==5.0.1
+pandas==1.5.3
 pendulum==2.1.2
 PyYAML==6.0
-SQLAlchemy==1.4.44
+SQLAlchemy<2.0.0
 sql-metadata==2.6.0

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ABSQL",
-    version="0.2.4",
+    version="0.3.0",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="A rendering engine for templated SQL",

--- a/tests/files/partial_planet.sql
+++ b/tests/files/partial_planet.sql
@@ -1,0 +1,5 @@
+---
+curly_planet: "{{planet()}}"
+---
+
+Hello {{planet()}}, Goodbye {{curly_planet}}

--- a/tests/functions/test_db.py
+++ b/tests/functions/test_db.py
@@ -10,16 +10,16 @@ from absql import Runner
 @pytest.fixture(scope="module")
 def engine():
     engine = create_engine("duckdb:///:memory:")
+
+    df = DataFrame.from_dict(
+        {
+            "name": ["Thelma", "Bonnie"],
+            "friend": ["Louise", "Clyde"],
+            "empty": [None, None],
+        }
+    )
+
     with engine.connect() as connection:
-
-        df = DataFrame.from_dict(
-            {
-                "name": ["Thelma", "Bonnie"],
-                "friend": ["Louise", "Clyde"],
-                "empty": [None, None],
-            }
-        )
-
         with connection.begin():
             df.to_sql("my_table", connection)
 

--- a/tests/functions/test_db.py
+++ b/tests/functions/test_db.py
@@ -10,19 +10,19 @@ from absql import Runner
 @pytest.fixture(scope="module")
 def engine():
     engine = create_engine("duckdb:///:memory:")
-    engine.execute(
-        "register",
-        (
-            "my_table",
-            DataFrame.from_dict(
-                {
-                    "name": ["Thelma", "Bonnie"],
-                    "friend": ["Louise", "Clyde"],
-                    "empty": [None, None],
-                }
-            ),
-        ),
-    )
+    with engine.connect() as connection:
+
+        df = DataFrame.from_dict(
+            {
+                "name": ["Thelma", "Bonnie"],
+                "friend": ["Louise", "Clyde"],
+                "empty": [None, None],
+            }
+        )
+
+        with connection.begin():
+            df.to_sql("my_table", connection)
+
     return engine
 
 

--- a/tests/test_partial_kwargs.py
+++ b/tests/test_partial_kwargs.py
@@ -25,3 +25,14 @@ def test_render_text_extra_partial(planet):
 def test_default_render_text_extra_partial_fails(planet):
     with pytest.raises(TypeError):
         Runner.render_text("Hello {{planet()}}", planet=planet, planet_name="Earth")
+
+
+def test_render_file_extra_partial(planet):
+    got = Runner.render_file(
+        "tests/files/partial_planet.sql",
+        planet=planet,
+        planet_name="Earth",
+        partial_kwargs=["planet_name"],
+    )
+    want = "Hello Earth, Goodbye Earth"
+    assert got == want

--- a/tests/test_partial_kwargs.py
+++ b/tests/test_partial_kwargs.py
@@ -36,3 +36,13 @@ def test_render_file_extra_partial(planet):
     )
     want = "Hello Earth, Goodbye Earth"
     assert got == want
+
+
+def test_render_runner_extra_partial(planet):
+    r = Runner(planet=planet, planet_name="Earth", partial_kwargs=["planet_name"])
+    text_got = r.render("Hello {{planet()}}")
+    text_want = "Hello Earth"
+    assert text_got == text_want
+    file_got = r.render("tests/files/partial_planet.sql")
+    file_want = "Hello Earth, Goodbye Earth"
+    assert file_got == file_want

--- a/tests/test_partial_kwargs.py
+++ b/tests/test_partial_kwargs.py
@@ -2,9 +2,15 @@ import pytest
 from absql import Runner
 
 
-def test_render_text_extra_partial():
+@pytest.fixture()
+def planet():
     def planet(planet_name):
         return planet_name
+
+    return planet
+
+
+def test_render_text_extra_partial(planet):
 
     got = Runner.render_text(
         "Hello {{planet()}}",
@@ -16,9 +22,6 @@ def test_render_text_extra_partial():
     assert got == want
 
 
-def test_default_render_text_extra_partial_fails():
-    def planet(planet_name):
-        return planet_name
-
+def test_default_render_text_extra_partial_fails(planet):
     with pytest.raises(TypeError):
         Runner.render_text("Hello {{planet()}}", planet=planet, planet_name="Earth")

--- a/tests/test_partial_kwargs.py
+++ b/tests/test_partial_kwargs.py
@@ -1,0 +1,24 @@
+import pytest
+from absql import Runner
+
+
+def test_render_text_extra_partial():
+    def planet(planet_name):
+        return planet_name
+
+    got = Runner.render_text(
+        "Hello {{planet()}}",
+        planet=planet,
+        planet_name="Earth",
+        partial_kwargs=["planet_name"],
+    )
+    want = "Hello Earth"
+    assert got == want
+
+
+def test_default_render_text_extra_partial_fails():
+    def planet(planet_name):
+        return planet_name
+
+    with pytest.raises(TypeError):
+        Runner.render_text("Hello {{planet()}}", planet=planet, planet_name="Earth")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from absql.utils import nested_apply, get_function_arg_names, partialize_engine_func
+from absql.utils import nested_apply, get_function_arg_names, partialize_function
 
 
 def test_simple_apply():
@@ -31,11 +31,11 @@ def test_get_function_arg_names():
     assert got == want
 
 
-def test_partialize_engine_func():
+def test_partialize_function():
     def simple_func(a, engine):
         return a + engine
 
-    simple_func = partialize_engine_func(simple_func, 7)
+    simple_func = partialize_function(simple_func, 7)
     got = simple_func(3)
     want = 10
     assert got == want

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,7 +35,7 @@ def test_partialize_function():
     def simple_func(a, engine):
         return a + engine
 
-    simple_func = partialize_function(simple_func, 7)
+    simple_func = partialize_function(simple_func, engine=7)
     got = simple_func(3)
     want = 10
     assert got == want


### PR DESCRIPTION
- Adds `partial_kwargs`: a list of function kwargs to partialize. This was previously hard-coded as `engine`, but can now be set by the user.

- Updates tests and built-in functions to be SQLAlchemy 2.x-compatible.

- Moves `render_[x]` functions to a submodule.