### PR TITLE
Allow document header for YAML files in frontmatter load

### DIFF
--- a/absql/files/parsers.py
+++ b/absql/files/parsers.py
@@ -8,7 +8,7 @@ FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
 def frontmatter_load(file_path, loader=None):
     """
     Loads YAML frontmatter. Expects a YAML block at the top of the file
-    that starts and ends with "---". In use in favor of frontmatter.load
+    that starts and ends with "---" (for non-YAML files). In use in favor of frontmatter.load
     so that custom dag_constructors (via PyYaml) can be used uniformly across
     all file types.
     """
@@ -16,7 +16,9 @@ def frontmatter_load(file_path, loader=None):
         loader = generate_loader()
     with open(file_path, "r") as file:
         text = "".join(file.readlines())
-        if text.startswith("---"):
+        # Valid YAML files can begin with a document header (i.e. '---') and doesn't require a terminating
+        # marker; therefore, the "frontmatter" doesn't necessarily need to begin and end with this string.
+        if text.startswith("---") and not file_path.endswith((".yml", ".yaml")):
             _, metadata, content = FM_BOUNDARY.split(text, 2)
             metadata = yaml.load(metadata, Loader=loader)
             content = content.strip("\n")

--- a/absql/files/parsers.py
+++ b/absql/files/parsers.py
@@ -8,16 +8,17 @@ FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
 def frontmatter_load(file_path, loader=None):
     """
     Loads YAML frontmatter. Expects a YAML block at the top of the file
-    that starts and ends with "---" (for non-YAML files). In use in favor of frontmatter.load
-    so that custom dag_constructors (via PyYaml) can be used uniformly across
-    all file types.
+    that starts and ends with "---" (for non-YAML files). In use in favor of
+    frontmatter.load so that custom dag_constructors (via PyYaml) can be used uniformly
+    across all file types.
     """
     if loader is None:
         loader = generate_loader()
     with open(file_path, "r") as file:
         text = "".join(file.readlines())
-        # Valid YAML files can begin with a document header (i.e. '---') and doesn't require a terminating
-        # marker; therefore, the "frontmatter" doesn't necessarily need to begin and end with this string.
+        # Valid YAML files can begin with a document header (i.e. '---') and doesn't
+        # require a terminating marker; therefore, the "frontmatter" doesn't necessarily
+        # need to begin and end with this string.
         if text.startswith("---") and not file_path.endswith((".yml", ".yaml")):
             _, metadata, content = FM_BOUNDARY.split(text, 2)
             metadata = yaml.load(metadata, Loader=loader)

--- a/tests/files/simple_with_doc_header.yml
+++ b/tests/files/simple_with_doc_header.yml
@@ -1,0 +1,4 @@
+---
+my_table_placeholder: my_table
+sql: |-
+  SELECT * FROM {{my_table_placeholder}}

--- a/tests/test_parse_file.py
+++ b/tests/test_parse_file.py
@@ -19,7 +19,10 @@ def test_simple_sql(simple_sql_path):
     argnames="yml_path",
     argvalues=[
         pytest.param("tests/files/simple.yml", id="simple_yml"),
-        pytest.param("tests/files/simple_with_doc_header.yml", id="simple_yml_with_doc_header")],
+        pytest.param(
+            "tests/files/simple_with_doc_header.yml", id="simple_yml_with_doc_header"
+        ),
+    ],
 )
 def test_simple_yml(yml_path):
     res = parse(yml_path)

--- a/tests/test_parse_file.py
+++ b/tests/test_parse_file.py
@@ -7,11 +7,6 @@ def simple_sql_path():
     return "tests/files/simple.sql"
 
 
-@pytest.fixture
-def simple_yml_path():
-    return "tests/files/simple.yml"
-
-
 def test_simple_sql(simple_sql_path):
     res = parse(simple_sql_path)
     assert "sql" in res.keys()
@@ -20,8 +15,14 @@ def test_simple_sql(simple_sql_path):
     assert res["sql"] == "SELECT * FROM {{my_table_placeholder}}"
 
 
-def test_simple_yml(simple_yml_path):
-    res = parse(simple_yml_path)
+@pytest.mark.parametrize(
+    argnames="yml_path",
+    argvalues=[
+        pytest.param("tests/files/simple.yml", id="simple_yml"),
+        pytest.param("tests/files/simple_with_doc_header.yml", id="simple_yml_with_doc_header")],
+)
+def test_simple_yml(yml_path):
+    res = parse(yml_path)
     assert "sql" in res.keys()
     assert "my_table_placeholder" in res.keys()
     assert res["my_table_placeholder"] == "my_table"

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -73,6 +73,7 @@ def test_replace_only_changes(runner):
     original_2 = runner.render("{{env_switch(foo='address')}} and {{greeting}}")
     assert original_2 == "value_unspecified and Hello"
 
+
 def test_runner_renders_yaml(runner):
     got = runner.render("tests/files/constructor.yml")
     want = "SELECT * FROM tabletable"


### PR DESCRIPTION
YAML files can include a document header per the [spec](https://yaml.org/refcard.html). At the same time a common linter like yamllint [specifically checks that a YAML file begins with this marker by default](https://yamllint.readthedocs.io/en/latest/rules.html#module-yamllint.rules.document_start).

When a document header is used in a YAML file, the file parsing breaks, specifically with an unpacking error, because it expects these files to both begin _and end_ with this document header string.  Instead of having users disallow document headers or ignore this type of linting check, let's handle it when loading frontmatter for these files.