### PR TITLE
v0.5.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,9 @@ jobs:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -33,7 +33,7 @@ jobs:
       run: |
         pytest --cov=./ --cov-report=xml
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml

--- a/absql/render/__init__.py
+++ b/absql/render/__init__.py
@@ -70,6 +70,7 @@ def render_file(
     file_context_from=None,
     pretty_encode=False,
     partial_kwargs=None,
+    return_dict=False,
     **extra_context,
 ):
     """
@@ -81,8 +82,7 @@ def render_file(
 
     file_contents = parse(file_path, loader=loader)
 
-    sql = file_contents["sql"]
-    file_contents.pop("sql")
+    sql = file_contents.pop("sql", "")
 
     if file_context_from:
         file_contents.update(file_contents.get(file_context_from, {}))
@@ -97,5 +97,9 @@ def render_file(
         partial_kwargs=partial_kwargs,
         **rendered_context,
     )
+
+    if return_dict:
+        rendered_context["sql"] = rendered
+        return rendered_context
 
     return rendered

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ABSQL",
-    version="0.5.0",
+    version="0.5.1",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="A rendering engine for templated SQL",

--- a/tests/test_render_file_return_dict.py
+++ b/tests/test_render_file_return_dict.py
@@ -1,0 +1,21 @@
+import pytest
+from absql import Runner as r
+
+
+@pytest.fixture
+def simple_yml_path():
+    return "tests/files/simple.yml"
+
+
+def test_render_file_return_dict(simple_yml_path):
+    file_as_dict = r.render_file(simple_yml_path, return_dict=True)
+    print(file_as_dict)
+    assert file_as_dict["my_table_placeholder"] == "my_table"
+    assert file_as_dict["sql"] == "SELECT * FROM my_table"
+
+
+def test_runner_return_dict(simple_yml_path):
+    runner = r()
+    file_as_dict = runner.render(simple_yml_path, return_dict=True)
+    assert file_as_dict["my_table_placeholder"] == "my_table"
+    assert file_as_dict["sql"] == "SELECT * FROM my_table"


### PR DESCRIPTION
- `render_file` function and `render` method can now return the entire rendered file contents as a dictionary by setting `return_dict=True`, allowing any file type to be rendered and returned in full.

- Bumped Github action versions.