### PR TITLE
v0.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1-slim-buster
+FROM python:3.12.2-slim-bullseye
 USER root
 
 # Python Requirements

--- a/absql/files/__init__.py
+++ b/absql/files/__init__.py
@@ -1,13 +1,13 @@
 import os
 from absql.utils import get_function_arg_names
 from absql.files.loader import generate_loader
-from absql.files.parsers import parse_generic, parse_sql
+from absql.files.parsers import parse_yml, parse_sql, parse_js, parse_py
 
 default_parsers = {
-    ".yml": parse_generic,
-    ".yaml": parse_generic,
-    ".js": parse_generic,
-    ".py": parse_generic,
+    ".yml": parse_yml,
+    ".yaml": parse_yml,
+    ".js": parse_js,
+    ".py": parse_py,
     ".sql": parse_sql,
 }
 

--- a/absql/files/parsers.py
+++ b/absql/files/parsers.py
@@ -1,5 +1,6 @@
 import re
 import yaml
+import jupytext
 from absql.files.loader import generate_loader
 
 FM_BOUNDARY = re.compile(r"^-{3,}\s*$", re.MULTILINE)
@@ -47,7 +48,7 @@ def frontmatter_load(file_path, loader=None):
     return {"metadata": metadata, "content": content}
 
 
-def parse_generic(file_path, loader=None):
+def parse_yml(file_path, loader=None):
     if loader is None:
         loader = generate_loader()
     raw_content = frontmatter_load(file_path, loader=loader)
@@ -61,4 +62,22 @@ def parse_sql(file_path, loader=None):
     raw_content = frontmatter_load(file_path, loader=loader)
     file_content = raw_content["metadata"]
     file_content["sql"] = raw_content["content"]
+    return file_content
+
+
+def parse_js(file_path, loader=None):
+    if loader is None:
+        loader = generate_loader()
+    raw_content = frontmatter_load(file_path, loader=loader)
+    file_content = raw_content["metadata"]
+    file_content["js"] = raw_content["content"]
+    return file_content
+
+
+def parse_py(file_path, loader=None):
+    if loader is None:
+        loader = generate_loader()
+    raw_content = jupytext.read(file_path)["cells"]
+    file_content = yaml.load(raw_content[0]["source"].replace("---", ""), Loader=loader)
+    file_content["py"] = raw_content[1]["source"]
     return file_content

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,7 @@ duckdb==0.10.1
 duckdb-engine==0.11.2
 flatdict==4.0.1
 Jinja2==3.1.3
+jupytext==1.16.1
 mock==5.1.0
 pandas
 pendulum==3.0.0

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setuptools.setup(
         "colorama",
         "flatdict",
         "Jinja2",
+        "jupytext",
         "pendulum",
         "PyYaml",
         "SQLAlchemy",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ABSQL",
-    version="0.5.2",
+    version="0.5.3",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="A rendering engine for templated SQL",

--- a/tests/files/simple.js
+++ b/tests/files/simple.js
@@ -1,0 +1,5 @@
+/*
+foo: bar
+*/
+
+console.log('hello')

--- a/tests/files/simple.py
+++ b/tests/files/simple.py
@@ -1,0 +1,5 @@
+# ---
+# foo: bar
+# ---
+
+print("hello")

--- a/tests/test_render_file_return_dict.py
+++ b/tests/test_render_file_return_dict.py
@@ -7,6 +7,16 @@ def simple_yml_path():
     return "tests/files/simple.yml"
 
 
+@pytest.fixture
+def simple_js_path():
+    return "tests/files/simple.js"
+
+
+@pytest.fixture
+def simple_py_path():
+    return "tests/files/simple.py"
+
+
 def test_render_file_return_dict(simple_yml_path):
     file_as_dict = r.render_file(simple_yml_path, return_dict=True)
     print(file_as_dict)
@@ -19,3 +29,17 @@ def test_runner_return_dict(simple_yml_path):
     file_as_dict = runner.render(simple_yml_path, return_dict=True)
     assert file_as_dict["my_table_placeholder"] == "my_table"
     assert file_as_dict["sql"] == "SELECT * FROM my_table"
+
+
+def test_render_file_return_dict_js(simple_js_path):
+    file_as_dict = r.render_file(simple_js_path, return_dict=True)
+    print(file_as_dict)
+    assert file_as_dict["foo"] == "bar"
+    assert file_as_dict["js"] == "console.log('hello')"
+
+
+def test_render_file_return_dict_py(simple_py_path):
+    file_as_dict = r.render_file(simple_py_path, return_dict=True)
+    print(file_as_dict)
+    assert file_as_dict["foo"] == "bar"
+    assert file_as_dict["py"] == 'print("hello")'


### PR DESCRIPTION
Every file has its own parser type. With the exception of YAML files, file contents are returned in the context dictionary as their file name (e.g. `.js` files have a `js` key)