### PR TITLE
Handle JS block comments the same as SQL block comments

### DIFF
--- a/absql/files/parsers.py
+++ b/absql/files/parsers.py
@@ -29,7 +29,7 @@ def frontmatter_load(file_path, loader=None):
             text = tmp_header + text
             metadata = {}
             content = yaml.load(text, Loader=loader)
-
+            content = content.replace(tmp_header, "")
         elif text.startswith("/*") and file_path.endswith((".sql", ".js")):
             # Retrieve the first matched set of text within a block comment
             # (i.e. /* ... */).

--- a/absql/files/parsers.py
+++ b/absql/files/parsers.py
@@ -29,8 +29,8 @@ def frontmatter_load(file_path, loader=None):
             text = tmp_header + text
             metadata = {}
             content = yaml.load(text, Loader=loader)
-            content = content.replace(tmp_header, "")
-        elif text.startswith("/*") and file_path.endswith(".sql"):
+
+        elif text.startswith("/*") and file_path.endswith((".sql", ".js")):
             # Retrieve the first matched set of text within a block comment
             # (i.e. /* ... */).
             metadata = (

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="ABSQL",
-    version="0.6.1",
+    version="0.6.2",
     author="Chris Cardillo",
     author_email="cfcardillo23@gmail.com",
     description="A rendering engine for templated SQL",

--- a/tests/files/backticks.js
+++ b/tests/files/backticks.js
@@ -1,0 +1,5 @@
+/*
+foo: bar
+*/
+
+console.log(`hello`)

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -29,6 +29,16 @@ def simple_sql_path():
 
 
 @pytest.fixture
+def simple_js_path():
+    return "tests/files/simple.js"
+
+
+@pytest.fixture
+def backticks_js_path():
+    return "tests/files/backticks.js"
+
+
+@pytest.fixture
 def no_frontmatter_path():
     return "tests/files/no_frontmatter.sql"
 
@@ -36,6 +46,16 @@ def no_frontmatter_path():
 def test_render_simple_sql(runner, simple_sql_path):
     sql = runner.render(simple_sql_path)
     assert sql == "SELECT * FROM my_table"
+
+
+def test_render_simple_js(runner, simple_js_path):
+    js = runner.render(simple_js_path)
+    assert js == "console.log('hello')"
+
+
+def test_render_backticks_js(runner, backticks_js_path):
+    js = runner.render(backticks_js_path)
+    assert js == "console.log(`hello`)"
 
 
 def test_render_no_frontmatter(runner, no_frontmatter_path):


### PR DESCRIPTION
YAML frontmatter should be handled the same way in Javascript as it is handled in SQL since the block comments are the same. Previously ABSQL attempted to parse the entire file as yaml and hit errors on backticks.