### PR TITLE
Remove flatdict dep in favor of explicit implementation

### DIFF
--- a/absql/text/__init__.py
+++ b/absql/text/__init__.py
@@ -3,6 +3,16 @@ from sql_metadata import Parser
 from colorama import Fore
 
 
+def _flatten(d, parent_key=""):
+    items = {}
+    for k, v in d.items():
+        new_key = f"{parent_key}.{k}" if parent_key else k
+        if isinstance(v, dict):
+            items.update(_flatten(v, new_key))
+        else:
+            items[new_key] = v
+    return items
+
 def clean_spacing(text):
     text = re.sub("\\{\\{", "{{ ", text)
     text = re.sub("\\}\\}", " }}", text)
@@ -18,18 +28,7 @@ def create_replacements(**kwargs):
         replacements.update(replacement)
     return replacements
 
-
 def flatten_inputs(**kwargs):
-    def _flatten(d, parent_key=""):
-        items = {}
-        for k, v in d.items():
-            new_key = f"{parent_key}.{k}" if parent_key else k
-            if isinstance(v, dict):
-                items.update(_flatten(v, new_key))
-            else:
-                items[new_key] = v
-        return items
-
     return _flatten(kwargs)
 
 

--- a/absql/text/__init__.py
+++ b/absql/text/__init__.py
@@ -1,5 +1,4 @@
 import re
-from flatdict import FlatDict
 from sql_metadata import Parser
 from colorama import Fore
 
@@ -21,8 +20,17 @@ def create_replacements(**kwargs):
 
 
 def flatten_inputs(**kwargs):
-    flattened = FlatDict(kwargs, delimiter=".")
-    return flattened
+    def _flatten(d, parent_key=""):
+        items = {}
+        for k, v in d.items():
+            new_key = f"{parent_key}.{k}" if parent_key else k
+            if isinstance(v, dict):
+                items.update(_flatten(v, new_key))
+            else:
+                items[new_key] = v
+        return items
+
+    return _flatten(kwargs)
 
 
 def pretty_encode_sql(

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 colorama==0.4.6
 duckdb==1.4.4
 duckdb-engine==0.17.0
-flatdict==4.1.0
 Jinja2==3.1.6
 jupytext==1.19.1
 mock==5.2.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "colorama",
-        "flatdict",
         "Jinja2",
         "jupytext",
         "pendulum",

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,4 +1,4 @@
-from absql.text import clean_spacing, create_replacements
+from absql.text import clean_spacing, create_replacements, flatten_inputs
 
 
 def test_clean_spaces():
@@ -31,3 +31,28 @@ def test_replacements():
     got = create_replacements(foo="bar")
     want = {"{{foo}}": "bar", "{{ foo }}": "bar"}
     assert got == want
+
+
+def test_flatten_inputs_flat():
+    got = flatten_inputs(a="1", b="2")
+    assert got == {"a": "1", "b": "2"}
+
+
+def test_flatten_inputs_nested():
+    got = flatten_inputs(config={"table": "my_table", "schema": "public"})
+    assert got == {"config.table": "my_table", "config.schema": "public"}
+
+
+def test_flatten_inputs_deeply_nested():
+    got = flatten_inputs(a={"b": {"c": "deep"}})
+    assert got == {"a.b.c": "deep"}
+
+
+def test_flatten_inputs_empty():
+    got = flatten_inputs()
+    assert got == {}
+
+
+def test_flatten_inputs_mixed():
+    got = flatten_inputs(top="value", nested={"key": "val"})
+    assert got == {"top": "value", "nested.key": "val"}


### PR DESCRIPTION
The `flatdict` package is unmaintained (last release 2020) and uses `pkg_resources`, which was removed in setuptools 82.0.0 (released February 9th), causing build failures in images using ABSQL. Building the `flatdict` wheel itself doesn't have a restriction on `pkg_resources` nor `setuptools` unfortunately so, this felt like the most appropriate place to resolve said build failures.

This replaces the `flatdict` import with a simple recursive helper inside `flatten_inputs()` and adds test coverage for the function. No behavioral changes.

Related: astronomer/sirius#3422