### PR TITLE
Require flatdict>=4.1.0 to resolve build failures

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 colorama==0.4.6
 duckdb==1.0.0
 duckdb-engine==0.13.0
-flatdict==4.0.1
+flatdict>=4.1.0
 Jinja2==3.1.4
 jupytext==1.16.2
 mock==5.1.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         "colorama",
-        "flatdict",
+        "flatdict>=4.1.0",
         "Jinja2",
         "jupytext",
         "pendulum",


### PR DESCRIPTION
## Summary
- Updates `flatdict` requirement from `4.0.1` (or unversioned) to `>=4.1.0` in both `setup.py` and `dev-requirements.txt`
- Resolves pkg_resources/setuptools build issues that affected flatdict 4.0.1
- Addresses the same issue that PR #12 attempted to fix, but using the upstream fix instead

## Background
flatdict 4.0.1 had a build failure due to using pkg_resources (which was removed from setuptools). The maintainers released flatdict 4.1.0 to fix this issue: https://github.com/gmr/flatdict/releases/tag/4.1.0

PR #12 attempted to work around this by implementing flatdict functionality directly, but now that an upstream fix is available, it's cleaner to simply require the fixed version.

## Test plan
- [x] Built Docker image successfully with flatdict 4.1.0
- [x] Ran test suite: 60/67 tests pass (7 pre-existing test failures unrelated to this change, confirmed on main branch)
- [x] Verified flatdict 4.1.0 is installed and functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)